### PR TITLE
feat: add minimal responsive portfolio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,15 +58,15 @@
         <div class="about-text">
           <h2>About Me</h2>
           <p>
-            I'm Kevin Jordan, a multimedia creative dedicated to crafting engaging
-            visuals and stories that connect.
+            I'm Kevin Jordan, a multimedia creative dedicated to crafting <span class="accent">engaging visuals</span>
+            and stories that connect.
           </p>
           <p>
-            From concept to final cut, I ensure every project reflects your
-            vision with precision and style.
+            From concept to final cut, I ensure every project reflects <span class="accent">your vision</span>
+            with precision and style.
           </p>
           <p>
-            Let's collaborate to bring your ideas to life with a personal touch
+            Let's collaborate to bring your ideas to life with a <span class="accent">personal touch</span>
             that stands out.
           </p>
           <div class="tags">
@@ -127,13 +127,18 @@
 
     <!-- Contact Section -->
     <section id="contact" class="contact hidden">
-      <h2 class="section-title">Contact Me</h2>
-      <form action="#">
-        <input type="text" placeholder="Name" required />
-        <input type="email" placeholder="Email" required />
-        <textarea placeholder="Message" required></textarea>
-        <button type="submit" class="btn btn-primary">Send</button>
-      </form>
+      <div class="contact-grid">
+        <div class="contact-info">
+          <h2 class="section-title">Contact Me</h2>
+          <p class="quote accent">"Let's build something remarkable together."</p>
+        </div>
+        <form action="#" class="contact-form">
+          <input type="text" placeholder="Name" required />
+          <input type="email" placeholder="Email" required />
+          <textarea placeholder="Message" required></textarea>
+          <button type="submit" class="btn btn-primary">Send</button>
+        </form>
+      </div>
     </section>
 
     <!-- Footer -->

--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kevin Jordan's Touch</title>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=DM+Serif+Display&family=Karla&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Site Styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Navigation Bar -->
+    <header class="navbar">
+      <div class="logo">Kevin Jordan's Touch</div>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="#hero">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#services">Services</a></li>
+          <li><a href="#portfolio">Portfolio</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <!-- Hero Section -->
+    <section id="hero" class="hero">
+      <h1>Kevin Jordan's Touch</h1>
+      <p>Your vision, my <span class="accent">touch</span></p>
+    </section>
+
+    <!-- About Me Section -->
+    <section id="about" class="about">
+      <h2>About Me</h2>
+      <p>
+        I'm Kevin Jordan, a multimedia creative dedicated to crafting engaging
+        visuals and stories that connect.
+      </p>
+    </section>
+
+    <!-- Services Section -->
+    <section id="services" class="services">
+      <h2>Services</h2>
+      <div class="service-list">
+        <div class="service-item">
+          <h3>Video Editing</h3>
+        </div>
+        <div class="service-item">
+          <h3>Social Media Management</h3>
+        </div>
+        <div class="service-item">
+          <h3>Photography</h3>
+        </div>
+      </div>
+    </section>
+
+    <!-- Portfolio Section -->
+    <section id="portfolio" class="portfolio">
+      <h2>Portfolio</h2>
+      <div class="portfolio-grid">
+        <!-- Work samples will go here -->
+      </div>
+    </section>
+
+    <!-- Newsletter Signup Section -->
+    <section id="newsletter" class="newsletter">
+      <h2>Stay in the Loop</h2>
+      <form action="#">
+        <input type="email" placeholder="Enter your email" required />
+        <button type="submit">Subscribe</button>
+      </form>
+    </section>
+
+    <!-- Contact Section -->
+    <section id="contact" class="contact">
+      <h2>Contact Me</h2>
+      <form action="#">
+        <input type="text" placeholder="Name" required />
+        <input type="email" placeholder="Email" required />
+        <textarea placeholder="Message" required></textarea>
+        <button type="submit">Send</button>
+      </form>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+      <p>&copy; 2024 Kevin Jordan's Touch</p>
+      <div class="social">
+        <a href="#">Twitter</a>
+        <a href="#">Instagram</a>
+        <a href="#">LinkedIn</a>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=DM+Serif+Display&family=Karla&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Karla&family=DM+Serif+Display&family=Caveat:wght@700&display=swap"
       rel="stylesheet"
     />
     <!-- Font Awesome for icons -->
@@ -40,78 +40,99 @@
     <!-- Hero Section -->
     <section id="hero" class="hero">
       <h1>Kevin Jordan's Touch</h1>
-      <p>Your vision, my <span class="accent">touch</span></p>
+      <p class="tagline">Your vision, my touch</p>
+      <div class="hero-cta">
+        <a href="#portfolio" class="btn btn-primary">View My Work</a>
+        <a href="#contact" class="btn btn-outline">Contact Me</a>
+      </div>
     </section>
 
-    <!-- About Me Section -->
-    <section id="about" class="about">
-      <div class="section-title"><h2>About Me</h2></div>
+    <!-- About Section -->
+    <section id="about" class="about hidden">
       <div class="about-content">
-        <img src="https://via.placeholder.com/500" alt="Kevin Jordan placeholder" />
+        <img
+          src="https://via.placeholder.com/500x600"
+          alt="Professional placeholder"
+          class="about-photo"
+        />
         <div class="about-text">
+          <h2>About Me</h2>
           <p>
-            I'm Kevin Jordan, a multimedia creative dedicated to crafting
-            engaging visuals and stories that connect.
+            I'm Kevin Jordan, a multimedia creative dedicated to crafting engaging
+            visuals and stories that connect.
           </p>
+          <p>
+            From concept to final cut, I ensure every project reflects your
+            vision with precision and style.
+          </p>
+          <p>
+            Let's collaborate to bring your ideas to life with a personal touch
+            that stands out.
+          </p>
+          <div class="tags">
+            <span class="tag">Creative Strategy</span>
+            <span class="tag">Digital Design</span>
+            <span class="tag">Storytelling</span>
+          </div>
         </div>
       </div>
     </section>
 
     <!-- Services Section -->
-    <section id="services" class="services">
-      <div class="section-title"><h2>Services</h2></div>
+    <section id="services" class="services hidden">
+      <h2 class="section-title">Services</h2>
       <div class="card-grid">
         <div class="card">
           <i class="fas fa-video"></i>
           <h3>Video Editing</h3>
+          <p>Cutting and polishing footage into compelling stories.</p>
         </div>
         <div class="card">
           <i class="fas fa-share-alt"></i>
           <h3>Social Media Management</h3>
+          <p>Strategic planning and content creation for your brand.</p>
         </div>
         <div class="card">
           <i class="fas fa-camera"></i>
           <h3>Photography</h3>
+          <p>Crisp imagery that captures your essence.</p>
         </div>
       </div>
     </section>
 
     <!-- Portfolio Section -->
-    <section id="portfolio" class="portfolio">
-      <div class="section-title"><h2>Portfolio</h2></div>
-      <div class="card-grid">
-        <div class="card">
-          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
-          <h3>Project One</h3>
+    <section id="portfolio" class="portfolio hidden">
+      <h2 class="section-title">Portfolio</h2>
+      <div class="portfolio-grid">
+        <div class="portfolio-card">
+          <img src="https://via.placeholder.com/400x300" alt="Project placeholder" />
+          <div class="portfolio-info">
+            <h3>Project One</h3>
+            <span class="category">Video</span>
+            <p>Short description of the project.</p>
+            <a href="#" class="btn btn-primary">View Project</a>
+          </div>
         </div>
-        <div class="card">
-          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
-          <h3>Project Two</h3>
-        </div>
-        <div class="card">
-          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
-          <h3>Project Three</h3>
+        <div class="portfolio-card">
+          <img src="https://via.placeholder.com/400x300" alt="Project placeholder" />
+          <div class="portfolio-info">
+            <h3>Project Two</h3>
+            <span class="category">Design</span>
+            <p>Short description of the project.</p>
+            <a href="#" class="btn btn-primary">View Project</a>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- Newsletter Signup Section -->
-    <section id="newsletter" class="newsletter">
-      <div class="section-title"><h2>Stay in the Loop</h2></div>
-      <form action="#">
-        <input type="email" placeholder="Enter your email" required />
-        <button type="submit">Subscribe</button>
-      </form>
-    </section>
-
     <!-- Contact Section -->
-    <section id="contact" class="contact">
-      <div class="section-title"><h2>Contact Me</h2></div>
+    <section id="contact" class="contact hidden">
+      <h2 class="section-title">Contact Me</h2>
       <form action="#">
         <input type="text" placeholder="Name" required />
         <input type="email" placeholder="Email" required />
         <textarea placeholder="Message" required></textarea>
-        <button type="submit">Send</button>
+        <button type="submit" class="btn btn-primary">Send</button>
       </form>
     </section>
 
@@ -119,9 +140,9 @@
     <footer class="footer">
       <p>&copy; 2024 Kevin Jordan's Touch</p>
       <div class="social">
-        <a href="#">Twitter</a>
-        <a href="#">Instagram</a>
-        <a href="#">LinkedIn</a>
+        <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+        <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+        <a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
       </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -11,16 +11,24 @@
       href="https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=DM+Serif+Display&family=Karla&display=swap"
       rel="stylesheet"
     />
+    <!-- Font Awesome for icons -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+      integrity="sha512-Fo3rlrZj/k7ujTTXN1+R7eJle1k2hz0C2opkTUMpH5FQZ4PdtGdlIQK5vPQn5Z0jlfDXe4x0C49q6VZp6xg9yg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <!-- Site Styles -->
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <!-- Navigation Bar -->
+    <!-- Sticky Navigation Bar -->
     <header class="navbar">
       <div class="logo">Kevin Jordan's Touch</div>
       <nav>
         <ul class="nav-links">
-          <li><a href="#hero">Home</a></li>
+          <li><a href="#hero" class="active">Home</a></li>
           <li><a href="#about">About</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#portfolio">Portfolio</a></li>
@@ -37,24 +45,32 @@
 
     <!-- About Me Section -->
     <section id="about" class="about">
-      <h2>About Me</h2>
-      <p>
-        I'm Kevin Jordan, a multimedia creative dedicated to crafting engaging
-        visuals and stories that connect.
-      </p>
+      <div class="section-title"><h2>About Me</h2></div>
+      <div class="about-content">
+        <img src="https://via.placeholder.com/500" alt="Kevin Jordan placeholder" />
+        <div class="about-text">
+          <p>
+            I'm Kevin Jordan, a multimedia creative dedicated to crafting
+            engaging visuals and stories that connect.
+          </p>
+        </div>
+      </div>
     </section>
 
     <!-- Services Section -->
     <section id="services" class="services">
-      <h2>Services</h2>
-      <div class="service-list">
-        <div class="service-item">
+      <div class="section-title"><h2>Services</h2></div>
+      <div class="card-grid">
+        <div class="card">
+          <i class="fas fa-video"></i>
           <h3>Video Editing</h3>
         </div>
-        <div class="service-item">
+        <div class="card">
+          <i class="fas fa-share-alt"></i>
           <h3>Social Media Management</h3>
         </div>
-        <div class="service-item">
+        <div class="card">
+          <i class="fas fa-camera"></i>
           <h3>Photography</h3>
         </div>
       </div>
@@ -62,15 +78,26 @@
 
     <!-- Portfolio Section -->
     <section id="portfolio" class="portfolio">
-      <h2>Portfolio</h2>
-      <div class="portfolio-grid">
-        <!-- Work samples will go here -->
+      <div class="section-title"><h2>Portfolio</h2></div>
+      <div class="card-grid">
+        <div class="card">
+          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
+          <h3>Project One</h3>
+        </div>
+        <div class="card">
+          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
+          <h3>Project Two</h3>
+        </div>
+        <div class="card">
+          <img src="https://via.placeholder.com/300x200" alt="Project placeholder" />
+          <h3>Project Three</h3>
+        </div>
       </div>
     </section>
 
     <!-- Newsletter Signup Section -->
     <section id="newsletter" class="newsletter">
-      <h2>Stay in the Loop</h2>
+      <div class="section-title"><h2>Stay in the Loop</h2></div>
       <form action="#">
         <input type="email" placeholder="Enter your email" required />
         <button type="submit">Subscribe</button>
@@ -79,7 +106,7 @@
 
     <!-- Contact Section -->
     <section id="contact" class="contact">
-      <h2>Contact Me</h2>
+      <div class="section-title"><h2>Contact Me</h2></div>
       <form action="#">
         <input type="text" placeholder="Name" required />
         <input type="email" placeholder="Email" required />
@@ -98,6 +125,7 @@
       </div>
     </footer>
 
+    <!-- Site Scripts -->
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1 @@
+// Placeholder for future JavaScript functionality

--- a/script.js
+++ b/script.js
@@ -1,8 +1,10 @@
-// Highlight navigation links on scroll
+// Highlight navigation links on scroll and reveal sections
 const sections = document.querySelectorAll('section');
 const navLinks = document.querySelectorAll('.nav-links a');
+const hiddenElements = document.querySelectorAll('.hidden');
 
-const observer = new IntersectionObserver(
+// Observer for navigation link highlighting
+const navObserver = new IntersectionObserver(
   (entries) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
@@ -16,4 +18,19 @@ const observer = new IntersectionObserver(
   { threshold: 0.6 }
 );
 
-sections.forEach((section) => observer.observe(section));
+sections.forEach((section) => navObserver.observe(section));
+
+// Observer for entrance animations
+const revealObserver = new IntersectionObserver(
+  (entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('show');
+        observer.unobserve(entry.target);
+      }
+    });
+  },
+  { threshold: 0.2 }
+);
+
+hiddenElements.forEach((el) => revealObserver.observe(el));

--- a/script.js
+++ b/script.js
@@ -1,1 +1,19 @@
-// Placeholder for future JavaScript functionality
+// Highlight navigation links on scroll
+const sections = document.querySelectorAll('section');
+const navLinks = document.querySelectorAll('.nav-links a');
+
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        navLinks.forEach((link) => link.classList.remove('active'));
+        const id = entry.target.getAttribute('id');
+        const activeLink = document.querySelector(`.nav-links a[href="#${id}"]`);
+        if (activeLink) activeLink.classList.add('active');
+      }
+    });
+  },
+  { threshold: 0.6 }
+);
+
+sections.forEach((section) => observer.observe(section));

--- a/style.css
+++ b/style.css
@@ -1,0 +1,148 @@
+/* Global Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Karla', sans-serif;
+  letter-spacing: -0.075em;
+  background: #fff;
+  color: #111;
+  line-height: 1.6;
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'DM Serif Display', serif;
+  letter-spacing: normal;
+}
+
+.accent {
+  font-family: 'Caveat', cursive;
+  font-weight: 700;
+  color: #ffcc66;
+}
+
+/* Navigation Bar */
+.navbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: #fff;
+  z-index: 1000;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: #111;
+}
+
+/* Hero Section */
+.hero {
+  text-align: center;
+  padding: 6rem 1rem;
+}
+
+.hero h1 {
+  font-size: 3rem;
+}
+
+.hero p {
+  font-size: 1.25rem;
+  margin-top: 1rem;
+}
+
+/* Generic Section Styles */
+section {
+  padding: 4rem 1rem;
+  max-width: 1000px;
+  margin: auto;
+}
+
+/* Services Section */
+.service-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .service-list {
+    flex-direction: row;
+  }
+}
+
+/* Portfolio Section */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .portfolio-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Forms */
+.newsletter form,
+.contact form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: auto;
+}
+
+.newsletter input,
+.contact input,
+.contact textarea {
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+}
+
+.newsletter button,
+.contact button {
+  padding: 0.75rem;
+  border: none;
+  background: #ffcc66;
+  cursor: pointer;
+}
+
+/* Footer */
+.footer {
+  background: #f7f7f7;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.footer .social a {
+  margin: 0 0.5rem;
+  text-decoration: none;
+  color: #111;
+}
+
+/* Responsive Navigation */
+@media (max-width: 600px) {
+  .nav-links {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,10 @@
 /* Global Styles */
+:root {
+  --accent: #ffcc66;
+  --text: #111;
+  --bg: #fff;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -12,8 +18,8 @@ html {
 body {
   font-family: 'Karla', sans-serif;
   letter-spacing: -0.075em;
-  background: #fff;
-  color: #111;
+  background: var(--bg);
+  color: var(--text);
   line-height: 1.6;
 }
 
@@ -27,7 +33,19 @@ h3 {
 .accent {
   font-family: 'Caveat', cursive;
   font-weight: 700;
-  color: #ffcc66;
+  color: var(--accent);
+}
+
+section {
+  padding: 6rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  scroll-margin-top: 80px;
+}
+
+.section-title {
+  text-align: center;
+  margin-bottom: 3rem;
 }
 
 /* Navigation Bar */
@@ -38,25 +56,37 @@ h3 {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: #fff;
+  background: var(--bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   z-index: 1000;
 }
 
 .nav-links {
   list-style: none;
   display: flex;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .nav-links a {
   text-decoration: none;
-  color: #111;
+  color: var(--text);
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  color: var(--accent);
 }
 
 /* Hero Section */
 .hero {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   text-align: center;
-  padding: 6rem 1rem;
+  background: linear-gradient(135deg, var(--accent) 0%, #fff 100%);
 }
 
 .hero h1 {
@@ -64,41 +94,67 @@ h3 {
 }
 
 .hero p {
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   margin-top: 1rem;
 }
 
-/* Generic Section Styles */
-section {
-  padding: 4rem 1rem;
-  max-width: 1000px;
-  margin: auto;
-}
-
-/* Services Section */
-.service-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-@media (min-width: 768px) {
-  .service-list {
-    flex-direction: row;
-  }
-}
-
-/* Portfolio Section */
-.portfolio-grid {
+/* About Section */
+.about-content {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: 2rem;
+  align-items: center;
+}
+
+.about-content img {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 @media (min-width: 768px) {
-  .portfolio-grid {
+  .about-content {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* Card Grid */
+.card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .card-grid {
     grid-template-columns: repeat(3, 1fr);
   }
+}
+
+.card {
+  background: var(--bg);
+  padding: 2rem;
+  text-align: center;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.15);
+}
+
+.card i {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: var(--accent);
+}
+
+.card img {
+  width: 100%;
+  border-radius: 4px;
+  margin-bottom: 1rem;
 }
 
 /* Forms */
@@ -108,7 +164,7 @@ section {
   flex-direction: column;
   gap: 1rem;
   max-width: 400px;
-  margin: auto;
+  margin: 0 auto;
 }
 
 .newsletter input,
@@ -116,14 +172,20 @@ section {
 .contact textarea {
   padding: 0.75rem;
   border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 .newsletter button,
 .contact button {
   padding: 0.75rem;
   border: none;
-  background: #ffcc66;
+  background: var(--accent);
   cursor: pointer;
+}
+
+.newsletter button:hover,
+.contact button:hover {
+  opacity: 0.9;
 }
 
 /* Footer */
@@ -136,7 +198,11 @@ section {
 .footer .social a {
   margin: 0 0.5rem;
   text-decoration: none;
-  color: #111;
+  color: var(--text);
+}
+
+.footer .social a:hover {
+  color: var(--accent);
 }
 
 /* Responsive Navigation */

--- a/style.css
+++ b/style.css
@@ -1,8 +1,10 @@
-/* Global Styles */
+/* Global Variables */
 :root {
+  --bg: #0f0f0f;
+  --bg-alt: #141414;
+  --text: #eeeeee;
   --accent: #ffcc66;
-  --text: #111;
-  --bg: #fff;
+  --dark: #1a1a1a;
 }
 
 * {
@@ -17,7 +19,7 @@ html {
 
 body {
   font-family: 'Karla', sans-serif;
-  letter-spacing: -0.075em;
+  letter-spacing: -0.75px;
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
@@ -30,34 +32,37 @@ h3 {
   letter-spacing: normal;
 }
 
-.accent {
+.tagline {
   font-family: 'Caveat', cursive;
   font-weight: 700;
   color: var(--accent);
 }
 
 section {
-  padding: 6rem 1rem;
-  max-width: 1200px;
-  margin: 0 auto;
-  scroll-margin-top: 80px;
+  padding: 4rem 1.5rem;
+}
+
+section:nth-of-type(even) {
+  background: var(--bg-alt);
 }
 
 .section-title {
   text-align: center;
-  margin-bottom: 3rem;
+  margin-bottom: 2rem;
 }
 
 /* Navigation Bar */
 .navbar {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: var(--bg);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background: rgba(15, 15, 15, 0.6);
+  backdrop-filter: blur(10px);
   z-index: 1000;
 }
 
@@ -68,9 +73,9 @@ section {
 }
 
 .nav-links a {
-  text-decoration: none;
   color: var(--text);
-  transition: color 0.3s ease;
+  text-decoration: none;
+  transition: color 0.3s;
 }
 
 .nav-links a:hover,
@@ -86,16 +91,51 @@ section {
   justify-content: center;
   align-items: center;
   text-align: center;
-  background: linear-gradient(135deg, var(--accent) 0%, #fff 100%);
+  background: radial-gradient(circle at top, rgba(255, 204, 102, 0.15), var(--bg) 60%);
 }
 
 .hero h1 {
   font-size: 3rem;
 }
 
-.hero p {
+.hero .tagline {
   font-size: 1.5rem;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
+}
+
+.hero-cta {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--bg);
+  border: 2px solid var(--accent);
+}
+
+.btn-primary:hover {
+  box-shadow: 0 0 10px var(--accent);
+}
+
+.btn-outline {
+  border: 2px solid var(--accent);
+  color: var(--accent);
+}
+
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--bg);
+  box-shadow: 0 0 10px var(--accent);
 }
 
 /* About Section */
@@ -106,10 +146,32 @@ section {
   align-items: center;
 }
 
-.about-content img {
+.about-photo {
   width: 100%;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+}
+
+.about-text h2 {
+  margin-bottom: 1rem;
+}
+
+.about-text p {
+  margin-bottom: 1rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  background: #1f1f1f;
+  color: var(--text);
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
 }
 
 @media (min-width: 768px) {
@@ -118,7 +180,7 @@ section {
   }
 }
 
-/* Card Grid */
+/* Services Section */
 .card-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -132,17 +194,13 @@ section {
 }
 
 .card {
-  background: var(--bg);
+  background: var(--bg-alt);
   padding: 2rem;
   text-align: center;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  transition: transform 0.3s, box-shadow 0.3s;
+  border: 1px solid transparent;
 }
 
 .card i {
@@ -151,14 +209,74 @@ section {
   color: var(--accent);
 }
 
-.card img {
-  width: 100%;
-  border-radius: 4px;
-  margin-bottom: 1rem;
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 0 15px var(--accent);
+  border-color: var(--accent);
 }
 
-/* Forms */
-.newsletter form,
+/* Portfolio Section */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .portfolio-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.portfolio-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+.portfolio-card img {
+  width: 100%;
+  display: block;
+}
+
+.portfolio-info {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(15, 15, 15, 0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.3s;
+  padding: 1rem;
+}
+
+.portfolio-card:hover .portfolio-info {
+  opacity: 1;
+}
+
+.portfolio-info .category {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.portfolio-info p {
+  font-size: 0.9rem;
+  margin: 0.5rem 0 1rem;
+}
+
+/* Contact Section */
 .contact form {
   display: flex;
   flex-direction: column;
@@ -167,42 +285,52 @@ section {
   margin: 0 auto;
 }
 
-.newsletter input,
 .contact input,
 .contact textarea {
+  background: var(--bg-alt);
+  border: none;
   padding: 0.75rem;
-  border: 1px solid #ccc;
+  color: var(--text);
   border-radius: 4px;
 }
 
-.newsletter button,
-.contact button {
-  padding: 0.75rem;
-  border: none;
-  background: var(--accent);
-  cursor: pointer;
+.contact textarea {
+  resize: vertical;
+  min-height: 120px;
 }
 
-.newsletter button:hover,
-.contact button:hover {
-  opacity: 0.9;
+.contact button {
+  align-self: flex-start;
 }
 
 /* Footer */
 .footer {
-  background: #f7f7f7;
+  background: var(--dark);
   text-align: center;
   padding: 2rem 1rem;
 }
 
 .footer .social a {
-  margin: 0 0.5rem;
-  text-decoration: none;
   color: var(--text);
+  margin: 0 0.5rem;
+  font-size: 1.2rem;
+  transition: color 0.3s;
 }
 
 .footer .social a:hover {
   color: var(--accent);
+}
+
+/* Animations */
+.hidden {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Responsive Navigation */
@@ -210,5 +338,9 @@ section {
   .nav-links {
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  .hero h1 {
+    font-size: 2.5rem;
   }
 }

--- a/style.css
+++ b/style.css
@@ -32,7 +32,8 @@ h3 {
   letter-spacing: normal;
 }
 
-.tagline {
+.tagline,
+.accent {
   font-family: 'Caveat', cursive;
   font-weight: 700;
   color: var(--accent);
@@ -277,16 +278,31 @@ section:nth-of-type(even) {
 }
 
 /* Contact Section */
-.contact form {
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+  align-items: center;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .contact-grid {
+    grid-template-columns: 1fr 1fr;
+    text-align: left;
+  }
+}
+
+.contact-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  max-width: 400px;
-  margin: 0 auto;
 }
 
-.contact input,
-.contact textarea {
+.contact-form input,
+.contact-form textarea {
   background: var(--bg-alt);
   border: none;
   padding: 0.75rem;
@@ -294,13 +310,18 @@ section:nth-of-type(even) {
   border-radius: 4px;
 }
 
-.contact textarea {
+.contact-form textarea {
   resize: vertical;
   min-height: 120px;
 }
 
-.contact button {
+.contact-form button {
   align-self: flex-start;
+}
+
+.quote {
+  font-size: 1.25rem;
+  margin-top: 1rem;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- add responsive personal portfolio layout with hero, about, services, portfolio, newsletter, and contact sections
- style with Google Fonts (Karla, DM Serif Display, Caveat) and highlight accents
- include placeholder script file for future enhancements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3e3e80dc8321986b3aaadeb3327f