### PR TITLE
Add responsive dark-themed portfolio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kevin Jordan's Touch</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:wght@700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="navbar">
+        <nav>
+            <ul>
+                <li><a href="#hero" class="nav-link active">Home</a></li>
+                <li><a href="#about" class="nav-link">About</a></li>
+                <li><a href="#services" class="nav-link">Services</a></li>
+                <li><a href="#portfolio" class="nav-link">Portfolio</a></li>
+                <li><a href="#contact" class="nav-link">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <section id="hero" class="hero section">
+        <div class="hero-content">
+            <h1>Kevin Jordan’s Touch</h1>
+            <p>Your vision, my <em>touch</em></p>
+            <div class="buttons">
+                <a href="#portfolio" class="btn">View My Work</a>
+                <a href="#about" class="btn secondary">Learn More</a>
+            </div>
+        </div>
+    </section>
+
+    <section id="about" class="about section reveal">
+        <div class="about-content">
+            <div class="text">
+                <h2>About me.</h2>
+                <p>Good storytelling doesn’t need to shout – it just needs to be true.</p>
+                <p>I don’t just create content – I turn ideas into timeless stories that speak.</p>
+                <p>Not just to sell, but to resonate.</p>
+                <p>In a world drowning in fast-paced, shallow, overproduced ads, a wave of authentic, raw, and deeply human storytelling is rising. People are grasping for the last traces of real emotion and humanness in a digital era that threatens to strip it away. No gimmicks. No noise.</p>
+                <p>Just visual poetry that stays with you.</p>
+                <p>Something that doesn’t just make your brand seen, but felt.</p>
+                <p>Something that leaves a lasting imprint, turning clients into loyal fans and friends – not just numbers who buy.</p>
+                <p>Are you in?</p>
+            </div>
+            <div class="image">
+                <img src="assets/portrait.jpg" alt="Portrait of Kevin Jordan">
+            </div>
+        </div>
+    </section>
+
+    <section id="services" class="services section reveal">
+        <h2>Services</h2>
+        <div class="service-cards">
+            <div class="card">
+                <img src="assets/icons/video.svg" alt="Video Editing icon">
+                <h3>Video Editing</h3>
+                <p>Professional editing for polished storytelling.</p>
+            </div>
+            <div class="card">
+                <img src="assets/icons/social.svg" alt="Social Media Management icon">
+                <h3>Social Media Management</h3>
+                <p>Strategic planning to grow your online presence.</p>
+            </div>
+            <div class="card">
+                <img src="assets/icons/photo.svg" alt="Photography icon">
+                <h3>Photography</h3>
+                <p>Capturing moments that resonate and inspire.</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="portfolio" class="portfolio section reveal">
+        <h2>Portfolio</h2>
+        <div class="projects">
+            <div class="project">
+                <h3>Project One</h3>
+                <p>A showcase of storytelling through film.</p>
+                <a href="#" class="btn project-btn">View Project</a>
+            </div>
+            <div class="project">
+                <h3>Project Two</h3>
+                <p>Social campaign that drove real engagement.</p>
+                <a href="#" class="btn project-btn">View Project</a>
+            </div>
+            <div class="project">
+                <h3>Project Three</h3>
+                <p>Photography series capturing raw emotion.</p>
+                <a href="#" class="btn project-btn">View Project</a>
+            </div>
+            <div class="project">
+                <h3>Project Four</h3>
+                <p>Visual narrative that left a lasting imprint.</p>
+                <a href="#" class="btn project-btn">View Project</a>
+            </div>
+        </div>
+    </section>
+
+    <section id="contact" class="contact section reveal">
+        <h2>Contact</h2>
+        <form class="contact-form">
+            <input type="text" name="name" placeholder="Name" required>
+            <input type="email" name="email" placeholder="Email" required>
+            <textarea name="message" rows="5" placeholder="Message" required></textarea>
+            <button type="submit" class="btn">Send Message</button>
+        </form>
+    </section>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,28 @@
+// Smooth scrolling handled via CSS scroll-behavior
+// Intersection Observer for reveal animations
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+    }
+  });
+}, { threshold: 0.2 });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Navbar link highlighting
+const sections = document.querySelectorAll('section');
+const navLinks = document.querySelectorAll('.nav-link');
+
+const navObserver = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      navLinks.forEach(link => {
+        link.classList.toggle('active', link.getAttribute('href').slice(1) === entry.target.id);
+      });
+    }
+  });
+}, { threshold: 0.6 });
+
+sections.forEach(section => navObserver.observe(section));
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,246 @@
+/* Base Styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+html {
+    scroll-behavior: smooth;
+}
+body {
+    background-color: #0e0e0e;
+    color: #b3b3b3;
+    font-family: 'Inter', sans-serif;
+    line-height: 1.6;
+}
+h1, h2, h3 {
+    font-family: 'Fraunces', serif;
+    color: #f7c94b;
+}
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+/* Navbar */
+.navbar {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    background: rgba(14, 14, 14, 0.9);
+    z-index: 1000;
+}
+.navbar ul {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    list-style: none;
+    padding: 1rem 0;
+}
+.navbar a {
+    transition: color 0.3s;
+}
+.navbar a.active,
+.navbar a:hover {
+    color: #f7c94b;
+}
+
+/* Sections */
+.section {
+    padding: 100px 20px;
+}
+
+/* Hero */
+.hero {
+    height: 100vh;
+    background: url('assets/hero.jpg') center/cover no-repeat;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(14,14,14,0.6);
+}
+.hero-content {
+    position: relative;
+    z-index: 1;
+    animation: fadeInUp 1s ease-out forwards;
+    opacity: 0;
+    transform: translateY(20px);
+}
+.hero-content h1 {
+    font-size: 3rem;
+}
+.hero-content p {
+    margin: 1rem 0;
+}
+.buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+/* Buttons */
+.btn {
+    background: #ffc66d;
+    color: #000000;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.3s, background 0.3s;
+    display: inline-block;
+    font-weight: 500;
+}
+.btn.secondary {
+    background: transparent;
+    color: #f7c94b;
+    border: 1px solid #f7c94b;
+}
+.btn:hover {
+    transform: scale(1.05);
+    background: #f7c94b;
+}
+.btn.secondary:hover {
+    background: #f7c94b;
+    color: #000;
+}
+
+/* About */
+.about-content {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+.about .text {
+    flex: 1;
+}
+.about .image {
+    flex: 1;
+    overflow: hidden;
+}
+.about img {
+    width: 100%;
+    display: block;
+    transition: transform 0.5s;
+}
+.about img:hover {
+    transform: scale(1.05);
+}
+
+/* Services */
+.services h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+.service-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+.card {
+    background: #1a1a1a;
+    padding: 2rem;
+    text-align: center;
+    border-radius: 8px;
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+.card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.3);
+}
+.card img {
+    width: 60px;
+    margin-bottom: 1rem;
+}
+
+/* Portfolio */
+.portfolio h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+.projects {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+.project {
+    background: #1a1a1a;
+    padding: 1.5rem;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+.project-btn {
+    margin-top: 1rem;
+    align-self: flex-start;
+}
+
+/* Contact */
+.contact h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+.contact-form {
+    max-width: 600px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.contact-form input,
+.contact-form textarea {
+    background: #1a1a1a;
+    border: 1px solid #b3b3b3;
+    padding: 0.75rem;
+    color: #b3b3b3;
+    font-family: inherit;
+}
+.contact-form input:focus,
+.contact-form textarea:focus {
+    outline: none;
+    border-color: #f7c94b;
+}
+
+/* Reveal Animation */
+.reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Keyframes */
+@keyframes fadeInUp {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .about-content {
+        flex-direction: column;
+    }
+    .navbar ul {
+        gap: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Build responsive single-page portfolio with hero, services, portfolio and contact sections
- Implement dark theme, sticky navigation and smooth scroll with IntersectionObserver animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac60ce1260832193878ea9c06adc25